### PR TITLE
[PROTOC] Exclude ./build directory

### DIFF
--- a/scripts/compile_protos.sh
+++ b/scripts/compile_protos.sh
@@ -16,6 +16,7 @@ ROOTLESS_PROTO_FILES="$(find $PWD \
                              $(for dir in $PROTO_ROOT_DIRS ; do echo "-path $dir -prune -o " ; done) \
                              -path $PWD/vendor -prune -o \
                              -path $PWD/gotools -prune -o \
+                             -path $PWD/build -prune -o \
                              -name "*.proto" -exec readlink -f {} \;)"
 ROOTLESS_PROTO_DIRS="$(dirname $ROOTLESS_PROTO_FILES | sort | uniq)"
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail. -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes #

## How Has This Been Tested?
<!-- If this PR does not contain a new test case, explain why. -->
<!-- Describe in detail how you tested your changes. -->

## Checklist:
<!-- To check a box, and an 'x': [x] -->
<!-- To uncheck box, add a space: [ ] -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] I have added a [Signed-off-by](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md#legal-stuff).
- [] I have either added documentation to cover my changes or this change requires no new documentation.
- [] I have either added unit tests to cover my changes or this change requires no new tests.
- [] I have run [golint](https://github.com/golang/lint) and have fixed valid warnings in code I have added or modified. This tool generates false positives so you may choose to ignore some warnings. The goal is clean, consistent, and readable code.

<!-- The continuous integration build process will run [make checks](https://github.com/hyperledger/fabric/blob/master/Makefile#L22) to confirm that tests pass and that code quality meets minimum standards. You may optionally run this locally as PRs will not be accepted until they pass. -->

Signed-off-by:

There's no reason to try to build anything from
within our temporary build location, and this will
because more heavily used later in the series.
Therefore, let's prepare for this eventuality
by harmlessly excluding it today.

Change-Id: I11d82a738c7ca2942c18ba7169c6ce2309091753
Signed-off-by: Gregory Haskins <gregory.haskins@gmail.com>